### PR TITLE
Fix wrong input order

### DIFF
--- a/examples/classifier/Evaluator.hs
+++ b/examples/classifier/Evaluator.hs
@@ -13,5 +13,5 @@ main :: IO ()
 main = do
     (server:port:args) <- getArgs
     let input = concat [ word2Bits (read w :: Word8) | w <- args ]
-    result <- connectTo server (read port) (evaluatorProto classifier input <=< simpleConn)
+    result <- connectTo server (read port) (evaluatorProto gtBinary input <=< simpleConn)
     print (bits2Word result :: Word8)

--- a/examples/classifier/Example/Classifier.hs
+++ b/examples/classifier/Example/Classifier.hs
@@ -8,8 +8,17 @@ import Control.Monad
 
 classifier :: Program Circuit
 classifier = L.buildCircuit $ do
-    g_bytes <- replicateM 5 (L.inputs 8 Garbler)
-    e_bytes <- replicateM 5 (L.inputs 8 Evaluator)
+    g_bytes <- replicateM 2 (L.inputs 8 Garbler)
+    e_bytes <- replicateM 2 (L.inputs 8 Evaluator)
     comps   <- zipWithM L.gtBinary g_bytes e_bytes
     res     <- L.ands comps
     return [res]
+
+-- to compare two numbers [0-127]
+-- return 1 if the first number is bigger, return 0 otherwise
+gtBinary :: Program Circuit
+gtBinary = L.buildCircuit $ do
+  g_bytes <- L.inputs 8 Garbler
+  e_bytes <- L.inputs 8 Evaluator
+  res <- L.gtBinary g_bytes e_bytes
+  return [res]

--- a/examples/classifier/Garbler.hs
+++ b/examples/classifier/Garbler.hs
@@ -13,5 +13,5 @@ main :: IO ()
 main = do
     (port:args) <- getArgs
     let input = concat [ word2Bits (read w :: Word8) | w <- args ]
-    result <- listenAt (read port) (garblerProto classifier input <=< simpleConn)
+    result <- listenAt (read port) (garblerProto gtBinary input <=< simpleConn)
     print (bits2Word result :: Word8)

--- a/src/Crypto/GarbledCircuits/Eval.hs
+++ b/src/Crypto/GarbledCircuits/Eval.hs
@@ -30,8 +30,8 @@ runEval k m ev = snd $ execState (runReaderT ev k) (0,m)
 eval :: Program GarbledGate -> AESKey128 -> [Wirelabel] -> [Wirelabel] -> [Wirelabel]
 eval prog key inpGb inpEv = trace (showGG prog inpGb inpEv) result
   where
-    initialResults = M.fromList (zip (S.toList (prog_input_gb prog)) inpGb) `M.union`
-                     M.fromList (zip (S.toList (prog_input_ev prog)) inpEv)
+    initialResults = M.fromList (zip (sortedInput readGGInput Garbler prog) inpGb) `M.union`
+                     M.fromList (zip (sortedInput readGGInput Evaluator prog) inpEv)
     resultMap = runEval key initialResults (eval' prog)
     result    = map (resultMap !!!) (prog_output prog)
 

--- a/src/Crypto/GarbledCircuits/Language.hs
+++ b/src/Crypto/GarbledCircuits/Language.hs
@@ -201,9 +201,8 @@ gtBit x y = not =<< leqBit x y
 
 -- |Compare two little-endian binary values.
 --
--- Note: I do not understand why we have to swap the arguments.
 gtBinary :: [Ref Circuit] -> [Ref Circuit] -> Builder (Ref Circuit)
-gtBinary xs ys = fst <$> gtHelper ys xs
+gtBinary xs ys = fst <$> gtHelper xs ys
   where
     gtHelper [x] [y] = do
         gt <- gtBit x y

--- a/src/Crypto/GarbledCircuits/TruthTable.hs
+++ b/src/Crypto/GarbledCircuits/TruthTable.hs
@@ -104,8 +104,8 @@ foldConst _ _ _ = err "foldConst" "unrecognized operation"
 evalTT :: [Bool] -> [Bool] -> Program TruthTable -> [Bool]
 evalTT inpGb inpEv prog = evalProg construct prog
   where
-    inputs Garbler   = M.fromList (zip (S.toList (prog_input_gb prog)) inpGb)
-    inputs Evaluator = M.fromList (zip (S.toList (prog_input_ev prog)) inpEv)
+    inputs Garbler   = M.fromList (zip (sortedInput readTTInput Garbler prog) inpGb)
+    inputs Evaluator = M.fromList (zip (sortedInput readTTInput Evaluator prog) inpEv)
 
     construct :: Ref TruthTable -> TruthTable -> [Bool] -> Bool
     construct ref (TTInp i p) [] = case M.lookup ref (inputs p) of


### PR DESCRIPTION
First of all, this repo's implementation for garbled circuits is by far the cleanest and most elegant I've seen 👍 Learned a lot from reading it.

When I was using it, I found a bug and managed to fix it.

### Problem
This approach builds garbled circuit from the output GarbledGate, it labels each gate and input with an incremental number as id. However, the input id of the garbled circuits might be different from the one for the ungarbled circuits. So when [the input set of the circuit is converted](https://github.com/spaceships/garbled-circuits/compare/master...zhangchiqing:master#diff-37eb3e0e568f419dc382fcf5cac4570aL107) into list, the order of the garbled circuit input might go wrong and pair with a different input bit from the user, leads to a wrong output.

### How to reproduce
I added an example to reproduce the bug. Here is how to reproduce it:
1. check out [this commit](https://github.com/spaceships/garbled-circuits/commit/374f34221f688a1e98226eeed7e1f23ec61dd2d2)
2. cd `examples/classifier`
3. `./build.sh`
4. `./classifier-garbler.a 5000 4`
5. In another terminal, put `./classifier-evaluator.a localhost 5000 3`
6. This should evaluate `4 > 3`, and expect to return `1` (True), but got `0` (False)

### How does the fix work
Since the `Env` contains the `InputId`, I sorted the input wires by input id in order to pair the user's input bits with the input of the garbled circuit in the right order.

Now, when I run the following command again, it can return `1` (True)
1. `./classifier-garbler.a 5000 4`
2. In another terminal, put `./classifier-evaluator.a localhost 5000 3`

If I swap the input data for Garbler and Evaluator, it returns `0`, which is correct.

And that's why [the unreasonable swapping](https://github.com/spaceships/garbled-circuits/compare/master...zhangchiqing:master#diff-d27b06f85a9b2a5b260d13ff620adf15L204) is unnecessary. 

Please review @spaceships 